### PR TITLE
Move 0-RTT text from DoQ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,21 +3,53 @@ jobs:
   build:
     docker:
       - image: martinthomson/i-d-template:latest
+    resource_class: small
     working_directory: ~/draft
 
     steps:
+      - run:
+          name: "Print Configuration"
+          command: |
+            xml2rfc --version
+            gem list -q kramdown-rfc2629
+            echo -n 'mmark '; mmark --version
+
+      - restore_cache:
+          name: "Restoring cache - Git"
+          keys:
+            - v2-cache-git-{{ .Branch }}-{{ .Revision }}
+            - v2-cache-git-{{ .Branch }}
+            - v2-cache-git-
+
+      - restore_cache:
+          name: "Restoring cache - References"
+          keys:
+            - v1-cache-references-{{ epoch }}
+            - v1-cache-references-
+
+      # Workaround for https://discuss.circleci.com/t/22437
+      - run:
+          name: Tag Checkout
+          command: |
+            if [ -n "$CIRCLE_TAG" ] && [ -d .git ]; then
+              remote=$(echo "$CIRCLE_REPOSITORY_URL" | \
+                       sed -e 's,/^git.github.com:,https://github.com/,')
+              git fetch -f "$remote" "refs/tags/$CIRCLE_TAG:refs/tags/$CIRCLE_TAG" || \
+                (echo 'Removing .git cache for tag build'; rm -rf .git)
+            fi
+
       - checkout
 
       # Build txt and html versions of drafts
       - run:
           name: "Build Drafts"
-          command: "make 'CLONE_ARGS=--reference ~/git-reference'"
+          command: make
 
       # Update editor's copy on gh-pages
       - run:
           name: "Update GitHub Pages"
           command: |
-            if [ "${CIRCLE_TAG#draft-}" == "${CIRCLE_TAG}" ]; then
+            if [ "${CIRCLE_TAG#draft-}" == "$CIRCLE_TAG" ]; then
               make gh-pages
             fi
 
@@ -25,14 +57,14 @@ jobs:
       - deploy:
           name: "Upload to Datatracker"
           command: |
-            if [ "${CIRCLE_TAG#draft-}" != "${CIRCLE_TAG}" ]; then
+            if [ "${CIRCLE_TAG#draft-}" != "$CIRCLE_TAG" ]; then
               make upload
             fi
 
-      # Save GitHub issues
+      # Archive GitHub Issues
       - run:
-          name: "Save GitHub Issues"
-          command: "make issues || make issues DISABLE_ISSUE_FETCH=true && make gh-issues"
+          name: "Archive GitHub Issues"
+          command: "make archive || make archive DISABLE_ARCHIVE_FETCH=true && make gh-archive"
 
       # Create and store artifacts
       - run:
@@ -41,6 +73,22 @@ jobs:
 
       - store_artifacts:
           path: /tmp/artifacts
+
+      - run:
+          name: "Prepare for Caching"
+          command: "git reflog expire --expire=now --all && git gc --prune=now"
+
+      - save_cache:
+          name: "Saving Cache - Git"
+          key: v2-cache-git-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/draft/.git
+
+      - save_cache:
+          name: "Saving Cache - Drafts"
+          key: v1-cache-references-{{ epoch }}
+          paths:
+            - ~/.cache/xml2rfc
 
 
 workflows:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# See http://editorconfig.org
+
+root = true
+
+[*.{md,xml,org}]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Automatically generated CODEOWNERS
+# Regenerate with `make update-codeowners`
+draft-ietf-dprive-early-data.md alessandro@cloudflare.com

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,33 @@
+name: "Archive Issues and Pull Requests"
+
+on:
+  schedule:
+    - cron: '0 0 * * 0,2,4'
+  repository_dispatch:
+    types: [archive]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: "Archive Issues and Pull Requests"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Update Archive"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: archive
+        token: ${{ github.token }}
+
+    - name: "Update GitHub Pages"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: gh-archive
+        token: ${{ github.token }}
+
+    - name: "Save Archive"
+      uses: actions/upload-artifact@v2
+      with:
+        path: archive.json

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -1,0 +1,60 @@
+name: "Update Editor's Copy"
+
+on:
+  push:
+    paths-ignore:
+    - README.md
+    - CONTRIBUTING.md
+    - LICENSE.md
+    - .gitignore
+  pull_request:
+    paths-ignore:
+    - README.md
+    - CONTRIBUTING.md
+    - LICENSE.md
+    - .gitignore
+
+jobs:
+  build:
+    name: "Update Editor's Copy"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Cache Setup"
+      id: cache-setup
+      run: |
+        mkdir -p "$HOME"/.cache/xml2rfc
+        echo "::set-output name=path::$HOME/.cache/xml2rfc"
+        date -u "+::set-output name=date::%FT%T"
+
+    - name: "Cache References"
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.cache-setup.outputs.path }}
+          .targets.mk
+        key: refcache-${{ steps.cache-setup.outputs.date }}
+        restore-keys: |
+          refcache-${{ steps.cache-setup.outputs.date }}
+          refcache-
+
+    - name: "Build Drafts"
+      uses: martinthomson/i-d-template@v1
+      with:
+        token: ${{ github.token }}
+
+    - name: "Update GitHub Pages"
+      uses: martinthomson/i-d-template@v1
+      if: ${{ github.event_name == 'push' }}
+      with:
+        make: gh-pages
+        token: ${{ github.token }}
+
+    - name: "Archive Built Drafts"
+      uses: actions/upload-artifact@v2
+      with:
+        path: |
+          draft-*.html
+          draft-*.txt

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+name: "Publish New Draft Version"
+
+on:
+  push:
+    tags:
+      - "draft-*"
+
+jobs:
+  build:
+    name: "Publish New Draft Version"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    # See https://github.com/actions/checkout/issues/290
+    - name: "Get Tag Annotations"
+      run: git fetch -f origin ${{ github.ref }}:${{ github.ref }}
+
+    - name: "Cache Setup"
+      id: cache-setup
+      run: |
+        mkdir -p "$HOME"/.cache/xml2rfc
+        echo "::set-output name=path::$HOME/.cache/xml2rfc"
+        date -u "+::set-output name=date::%FT%T"
+
+    - name: "Cache References"
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.cache-setup.outputs.path }}
+          .targets.mk
+        key: refcache-${{ steps.date.outputs.date }}
+        restore-keys: |
+          refcache-${{ steps.date.outputs.date }}
+          refcache-
+
+    - name: "Build Drafts"
+      uses: martinthomson/i-d-template@v1
+      with:
+        token: ${{ github.token }}
+
+    - name: "Upload to Datatracker"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: upload
+
+    - name: "Archive Submitted Drafts"
+      uses: actions/upload-artifact@v2
+      with:
+        path: "draft-*-[0-9][0-9].xml"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,36 @@
+name: "Update generated files"
+# This rule is not run automatically.
+# It can be run manually to update all of the files that are part
+# of the template, specifically:
+#  - README.md
+#  - CONTRIBUTING.md
+#  - .note.xml
+#  - .github/CODEOWNERS
+#  - Makefile
+#
+#
+# This might be useful if you have:
+#  - added, removed, or renamed drafts (including after adoption)
+#  - added, removed, or changed draft editors
+#  - changed the title of drafts
+#
+# Note that this removes any customizations you have made to
+# the affected files.
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: "Update files"
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout"
+      uses: actions/checkout@v2
+
+    - name: "Update generated files"
+      uses: martinthomson/i-d-template@v1
+      with:
+        make: update-files
+        token: ${{ github.token }}
+
+    - name: "Push Update"
+      run: git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 *~
 /*-[0-9][0-9].xml
+archive.json
+draft-ietf-dprive-early-data.xml
 *.html
-issues.json
+lib
 *.pdf
-pulls.json
 *.redxml
 .refcache
 report.xml
@@ -13,5 +14,3 @@ report.xml
 *.txt
 *.upload
 venv/
-lib
-draft-ietf-dprive-early-data.xml

--- a/.note.xml
+++ b/.note.xml
@@ -1,0 +1,4 @@
+<note title="Discussion Venues" removeInRFC="true">
+<t>Source for this draft and an issue tracker can be found at
+    <eref target="https://github.com/bemasc/draft-ghedini-dprive-early-data"/>.</t>
+</note>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,17 +15,3 @@ repository constitutes Contributions to the IETF Standards Process
 You agree to comply with all applicable IETF policies and procedures, including,
 BCP 78, 79, the TLP, and the TLP rules regarding code components (e.g. being
 subject to a Simplified BSD License) in Contributions.
-
-
-## Other Resources
-
-Discussion of this work occurs on the
-[dprive working group mailing list](https://mailarchive.ietf.org/arch/browse/dprive/)
-([subscribe](https://www.ietf.org/mailman/listinfo/dprive)).  In addition to
-contributions in GitHub, you are encouraged to participate in discussions there.
-
-**Note**: Some working groups adopt a policy whereby substantive discussion of
-technical issues needs to occur on the mailing list.
-
-You might also like to familiarize yourself with other
-[working group documents](https://datatracker.ietf.org/wg/dprive/documents/).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 # License
 
 See the
-[guidelines for contributions](https://github.com/ghedo/draft-ghedini-dprive-early-data/blob/master/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/bemasc/draft-ghedini-dprive-early-data/blob/master/CONTRIBUTING.md).

--- a/Makefile
+++ b/Makefile
@@ -7,5 +7,5 @@ ifneq (,$(shell grep "path *= *$(LIBDIR)" .gitmodules 2>/dev/null))
 	git submodule update $(CLONE_ARGS) --init
 else
 	git clone -q --depth 10 $(CLONE_ARGS) \
-	    -b master https://github.com/martinthomson/i-d-template $(LIBDIR)
+	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
 # Using Early Data in DNS over TLS
 
-This is the working area for the individual Internet-Draft, "Using Early Data in DNS over TLS".
+This is the working area for the IETF [DPRIVE Working Group](https://datatracker.ietf.org/wg/dprive/documents/) Internet-Draft, "Using Early Data in DNS over TLS".
 
-* [Editor's Copy](https://ghedo.github.io/draft-ietf-dprive-early-data/#go.draft-ietf-dprive-early-data.html)
-* [Individual Draft](https://tools.ietf.org/html/draft-ietf-dprive-early-data)
-* [Compare Editor's Copy to Individual Draft](https://ghedo.github.io/draft-ietf-dprive-early-data/#go.draft-ietf-dprive-early-data.diff)
+* [Editor's Copy](https://bemasc.github.io/draft-ghedini-dprive-early-data/#go.draft-ietf-dprive-early-data.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-dprive-early-data)
+* [Working Group Draft](https://datatracker.ietf.org/doc/html/draft-ietf-dprive-early-data)
+* [Compare Editor's Copy to Working Group Draft](https://bemasc.github.io/draft-ghedini-dprive-early-data/#go.draft-ietf-dprive-early-data.diff)
 
-## Building the Draft
+
+## Contributing
+
+See the
+[guidelines for contributions](https://github.com/bemasc/draft-ghedini-dprive-early-data/blob/master/CONTRIBUTING.md).
+
+Contributions can be made by creating pull requests.
+The GitHub interface supports creating pull requests using the Edit (✏) button.
+
+
+## Command Line Usage
 
 Formatted text and HTML versions of the draft can be built using `make`.
 
@@ -14,11 +25,6 @@ Formatted text and HTML versions of the draft can be built using `make`.
 $ make
 ```
 
-This requires that you have the necessary software installed.  See
-[the instructions](https://github.com/martinthomson/i-d-template/blob/master/doc/SETUP.md).
+Command line usage requires that you have the necessary software installed.  See
+[the instructions](https://github.com/martinthomson/i-d-template/blob/main/doc/SETUP.md).
 
-
-## Contributing
-
-See the
-[guidelines for contributions](https://github.com/ghedo/draft-ietf-dprive-early-data/blob/master/CONTRIBUTING.md).

--- a/draft-ietf-dprive-early-data.md
+++ b/draft-ietf-dprive-early-data.md
@@ -5,6 +5,8 @@ abbrev: DNS Early Data
 category: std
 workgroup: DPRIVE
 
+ipr: trust200902
+
 stand_alone: yes
 pi: [toc, sortrefs, symrefs, docmapping]
 
@@ -17,8 +19,8 @@ author:
 
 --- abstract
 
-This document illustrates the risks of using TLS 1.3 early data with DNS over
-TLS, and specifies behaviors that can be adopted by clients and servers to
+This document illustrates the risks of using TLS 1.3 early data with encrypted
+DNS, and specifies behaviors that can be adopted by clients and servers to
 reduce those risks.
 
 --- middle
@@ -30,7 +32,8 @@ or early data, that allows clients to send data to servers in the first
 round-trip of a resumed connection without having to wait for the TLS handshake
 to complete.
 
-This can be used to send DNS queries to DNS over TLS {{!DOT=RFC7858}} servers
+This can be used to send DNS queries using DNS over TLS {{!DOT=RFC7858}} or
+another encrypted transport {{?DOH=RFC8484}}{{?DOQ=I-D.draft-ietf-dprive-dnsoquic}}
 without incurring in the cost of the additional round-trip required by the TLS
 handshake. This can provide significant performance improvements in cases where
 new DNS over TLS connections need to be established often such as on mobile
@@ -50,7 +53,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
 when, and only when, they appear in all capitals, as shown here.
 
-# Early Data in DNS over TLS
+# Early Data in Encrypted DNS {#body}
 
 Early data forms a single stream of data along with other application data,
 meaning that one or more DNS queries can either be partially or fully contained
@@ -63,44 +66,71 @@ future connections by providing the "early_data" TLS extension as part of a TLS
 session ticket, as well as limit the amount of early data it is willing to
 accept using the "max_early_data_size" field of the "early_data" extension.
 
-In addition to the mitigation mechanisms mandated in {{?TLS13}} that reduce the
-ability of an attacker to replay early data, but may not completely eliminate
-it, a server that decided to offer early data to clients MAY reject early data
-at the TLS layer, or delay the processing of early data after the handshake is
-completed.
+The 0-RTT mechanism SHOULD NOT be used to send DNS requests that are
+not "replayable" transactions. Our analysis so far shows that
+such replayable transactions can only be QUERY requests,
+although we may need to also consider NOTIFY requests once
+the analysis of NOTIFY services is complete, see {{the-notify-service}}.
 
-If the server rejects early data at the TLS layer, a client MUST forget
-information it optmisitically assumed about the onnection when sending early
-data, such as the negotiated protocol {{?ALPN=RFC7301}}. Any DNS queries sent
-in early data will need to be sent again, unless the client decides to abandon
-them.
+Servers MUST NOT execute non replayable transactions received in 0-RTT
+data. Servers MUST adopt one of the following behaviors:
 
-Not all types of DNS messages are safe to be sent as early data, as they might
-modfify the server's state, or expose sensitive data, through replay. Clients
-MUST NOT use early data to send messages that make use of opcodes other than
-"Query" and RR types not listed in the registry defined in {{registry}}. Servers
-receiving any of those messages MUST reply with a "FormErr" response code.
+* Queue the offending transaction and only execute it after the handshake
+has been completed, as discussed in {{Section E.5 of !TLS13}} and
+{{Section 4.1.1 of !RFC9001}}.
+* Reply to the offending transaction with a response code REFUSED and
+an Extended DNS Error Code (EDE) "Too Early", see
+{{reservation-of-extended-dns-error-code-too-early}}.
+* Report a fatal protocol error in the DNS transport (e.g. DOQ_PROTOCOL_ERROR,
+HTTP 425).
+
+For zone transfers, it would be possible to replay an XFR QUERY
+that had been sent in 0-RTT data. However the relevant authentication mechanisms
+(described in {{Section 9 of ?RFC9103}}) will ensure that the response is not sent by
+the primary until the identity of the secondary has been verified, i.e. the first
+behavior listed above.
+
+# Privacy Considerations
+
+The 0-RTT data can be replayed by adversaries. That data may trigger queries by
+a recursive resolver to authoritative resolvers. Adversaries may be able to
+pick a time at which the recursive resolver outgoing traffic is observable, and
+thus find out what name was queried for in the 0-RTT data.
+
+This risk is in fact a subset of the general problem of observing the behavior
+of the recursive resolver discussed in "DNS Privacy Considerations"
+{{?RFC9076}}. The attack is partially mitigated by reducing the observability
+of this traffic. However, the risk is amplified for 0-RTT data, because the
+attacker might replay it at chosen times, several times.
+
+{{Section 8 of ?TLS13}} requires that the capability to use 0-RTT
+data should be turned off by default, and only enabled if the user clearly
+understands the associated risks. In our case, allowing 0-RTT data
+provides significant performance gains, and we are concerned that a
+recommendation to not use it would simply be ignored.
+
+The prevention on allowing replayable transactions in 0-RTT data
+blocks the most obvious
+risks of replay attacks, as it only allows for transactions that will
+not change the long term state of the server.
+
+Attacks trying to assess the state of the cache are more powerful if
+the attacker can choose the time at which the 0-RTT data will be replayed.
+Such attacks are blocked if the server enforces single-use tickets, or
+if the server implements a combination of ClientHello
+recording and freshness checks, as specified in
+{{Section 8 of ?TLS13}}. These blocking mechanisms
+rely on shared state between all server instances in a server system. In
+the case of encrypted DNS, the protection against replay attacks on the
+DNS cache is achieved if this state is shared between all servers
+that share the same DNS cache.
+
+The attacks described above apply to the stub resolver to recursive
+resolver scenario, but similar attacks might be envisaged in the
+recursive resolver to authoritative resolver scenario, and the
+same mitigations apply.
 
 # Security Considerations
-
-## Information Exposure
-
-By replaying DNS queries that were captured when transmitted over early data,
-an attacker might be able to expose information about those queries, even if
-encrypted.
-
-For example, it's a common behavior for DNS servers to statefully rotate the
-order of RRs when replying to DNS queries for an RRSet that contains multiple
-RRs. If the order of rotation is predictable, replaying a captured early data
-DNS query and observing the order of RRs in DNS responses before and after the
-replayed query, might allow the attacker to confirm whether the query targeted
-a specific name that was suspected of being queried.
-
-When accepting early data, servers SHOULD either use fixed ordering for multiple
-RRs in the same DNS response or shuffle the RRs at random, but MUST NOT use
-stateful and deterministic ordering across multiple queries.
-
-## Denial of Service
 
 Accepting early data exposes a server to potential denial of service through
 the replay of queries that might be expensive to handle.
@@ -110,35 +140,14 @@ forced to retry them after the handshake is completed.
 
 # IANA Considerations
 
-This document has no actions for IANA.
+## Reservation of Extended DNS Error Code Too Early
 
-## Registry for DNS Resource Record (RR) TYPEs for TLS Early Data {#registry}
+IANA is requested to add the following value to
+the Extended DNS Error Codes registry {{!RFC8914}}:
 
-This document establishes a registry of DNS RR types that can be used within
-TLS early data, titled "DNS Resource Record (RR) TYPEs for Use with TLS Early
-Data", under the existing "Domain Name System (DNS) Parameters" heading.
-
-The entries in the registry are:
-
-| TYPE   | Reference       |
-|:-------|:----------------|
-| A      | [this document] |
-| NS     | [this document] |
-| CNAME  | [this document] |
-| SOA    | [this document] |
-| PTR    | [this document] |
-| MX     | [this document] |
-| TXT    | [this document] |
-| AAAA   | [this document] |
-| SRV    | [this document] |
-| DNAME  | [this document] |
-| DS     | [this document] |
-| DNSKEY | [this document] |
-
-The values in this registry MUST correspond to existing entries in the
-"Resource Record (RR) TYPEs" registry. Specifically, the value of the "TYPE"
-column for each entry in this new registry MUST match the value of the "TYPE"
-column of an entry in the "Resource Record (RR) TYPEs" registry.
+* INFO-CODE: TBD
+* Purpose: Too Early
+* Reference: This document
 
 --- back
 
@@ -147,3 +156,27 @@ column of an entry in the "Resource Record (RR) TYPEs" registry.
 Thanks to Martin Thomson, Mark Nottingham and Willy Tarreau for writing
 {{?RFC8470}} which heavily inspired this document, and to Daniel Kahn Gillmor
 and Colm MacCárthaigh who also provided important ideas and contributions.
+
+# The NOTIFY service
+
+This appendix discusses the issue of allowing NOTIFY to be sent in 0-RTT data.
+
+{{body}} says "The 0-RTT mechanism SHOULD NOT be
+used to send DNS requests that are not "replayable" transactions", and suggests
+this is limited to OPCODE QUERY. It might also be viable to propose that NOTIFY
+should be permitted in 0-RTT data because although it technically changes the
+state of the receiving server, the effect of replaying NOTIFYs has negligible
+impact in practice.
+
+NOTIFY messages prompt a secondary to either send an SOA query or an XFR
+request to the primary on the basis that a newer version of the zone is
+available. It has long been recognized that NOTIFYs can be forged and, in
+theory, used to cause a secondary to send repeated unnecessary requests to the
+primary. For this reason, most implementations have some form of throttling of the
+SOA/XFR queries triggered by the receipt of one or more NOTIFYs.
+
+{{?RFC9103}} describes the privacy risks associated with both NOTIFY and SOA queries
+and does not include addressing those risks within the scope of encrypting zone
+transfers. Given this, the privacy benefit of using encrypted transport for NOTIFY is not clear -
+but for the same reason, sending NOTIFY as 0-RTT data has no privacy risk above
+that of sending it using cleartext DNS.


### PR DESCRIPTION
This change just moves the 0-RTT-related text from https://github.com/huitema/dnsoquic/blob/master/draft-ietf-dprive-dnsoquic.md, with only slight changes to fit the document structure, generalize to DoT and DoH, and modernize markdown syntax.

All text here is due to the authors of that draft.